### PR TITLE
Avoid numeric precision loss in numeric IDs returned by APIv2

### DIFF
--- a/src/DataSources/Clients.js
+++ b/src/DataSources/Clients.js
@@ -25,7 +25,8 @@ class ClientDataSource {
         clientSecret: await config.get('APIV2_CLIENT_SECRET'),
         timeout: await config.get('api.timeout'),
         oauthUrl: await config.get('api.oauthUrl'),
-        apiUrl: await config.get('api.apiUrl')
+        apiUrl: await config.get('api.apiUrl'),
+        bigIntsToStrings: await config.get('api.bigIntsToStrings')
       }));
     }
   }


### PR DESCRIPTION
This leverages the code change I'm proposing in:

https://github.com/classy-org/classy-api-client/pull/3