### PR TITLE
Support disabling Bugsnag (to be used by lambda script)

### DIFF
--- a/src/DataSources/Environment.ts
+++ b/src/DataSources/Environment.ts
@@ -5,11 +5,13 @@ const yamljs = require('yamljs');
 const fs = require('fs');
 
 import {DataSource, DataSourceConfig} from '../DataSource';
+import {stringToBoolean} from '../utils/utils';
 
 class EnvironmentDataSource extends DataSource {
   private dir?: string = process.env.PWD;
   private stage: string = 'dev';
   private dryRun: boolean = false;
+  private bugsnagEnabled: boolean = true;
   private environment?: object;
 
   public async initialize(config: DataSourceConfig) {
@@ -21,7 +23,10 @@ class EnvironmentDataSource extends DataSource {
       this.stage = process.env.AWS_LAMBDA_FUNCTION_NAME.split('-')[2];
     }
 
-    this.dryRun = process.env.DRYRUN ? Boolean(process.env.DRYRUN) : this.dryRun;
+    this.dryRun = process.env.DRYRUN ? stringToBoolean(process.env.DRYRUN) : this.dryRun;
+    this.bugsnagEnabled = process.env.BUGSNAG_ENABLED ?
+      stringToBoolean(process.env.BUGSNAG_ENABLED)
+      : this.bugsnagEnabled;
 
     const environment = {};
 
@@ -52,6 +57,8 @@ class EnvironmentDataSource extends DataSource {
         return this.stage;
       case 'dryRun':
         return this.dryRun;
+      case 'bugsnagEnabled':
+        return this.bugsnagEnabled;
       default:
         return _.get(this.environment, key, null);
     }

--- a/src/DataSources/Environment.ts
+++ b/src/DataSources/Environment.ts
@@ -23,10 +23,8 @@ class EnvironmentDataSource extends DataSource {
       this.stage = process.env.AWS_LAMBDA_FUNCTION_NAME.split('-')[2];
     }
 
-    this.dryRun = process.env.DRYRUN ? stringToBoolean(process.env.DRYRUN) : this.dryRun;
-    this.bugsnagEnabled = process.env.BUGSNAG_ENABLED ?
-      stringToBoolean(process.env.BUGSNAG_ENABLED)
-      : this.bugsnagEnabled;
+    this.dryRun = stringToBoolean(process.env.DRYRUN, this.dryRun);
+    this.bugsnagEnabled = stringToBoolean(process.env.BUGSNAG_ENABLED, this.bugsnagEnabled);
 
     const environment = {};
 

--- a/src/aws/handler.ts
+++ b/src/aws/handler.ts
@@ -33,7 +33,9 @@ export const handlerGenerator = (handler: ClassyAWSHandler, appName: string) => 
         result = await handler(event, context, config);
       } catch (e) {
         error = e.toString() === '[object Object]' ? new Error(JSON.stringify(e)) : e;
-        await promisify(bugsnag.notify)(error);
+        if (await config.get('bugsnagEnabled')) {
+          await promisify(bugsnag.notify)(error);
+        }
       } finally {
         callback(error, result);
       }

--- a/src/aws/handler.ts
+++ b/src/aws/handler.ts
@@ -16,7 +16,11 @@ export const handlerGenerator = (handler: ClassyAWSHandler, appName: string) => 
 
   const once = new Once(async () => {
     config = new AWSConfig(appName);
-    await BugsnagFactory.initialize(appName, await config.get('BUGSNAG_LAMBDAS_KEY'), await config.get('stage'));
+    const bugsnagEnabled = await config.get('bugsnagEnabled');
+
+    if (bugsnagEnabled) {
+      await BugsnagFactory.initialize(appName, await config.get('BUGSNAG_LAMBDAS_KEY'), await config.get('stage'));
+    }
   });
 
   return (event: any, context: AWSLambda.Context, callback: AWSLambda.Callback<any>) => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import _ = require('lodash');
+
 export const safeStrConcat = (strings: Array<any>): string => {
   let output = '';
   for (const s of strings) {
@@ -35,3 +37,16 @@ export const normalizeUrl = (inputUrl: string): string => {
 const jsonParse = require('json-bigint')({ storeAsString: true }).parse;
 
 export const JSONParseBig = (json: string): any => require('json-bigint')({ storeAsString: true }).parse(json);
+
+export const stringToBoolean = (input: string): boolean => {
+  if (input) {
+    if (_.toLower(input) === 'true') {
+      return true;
+    }
+    const n = parseFloat(input);
+    if (isFinite(n) && !isNaN(n) && n > 0) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -38,7 +38,7 @@ const jsonParse = require('json-bigint')({ storeAsString: true }).parse;
 
 export const JSONParseBig = (json: string): any => require('json-bigint')({ storeAsString: true }).parse(json);
 
-export const stringToBoolean = (input: string): boolean => {
+export const stringToBoolean = (input: string|undefined, defaultValue: boolean = false): boolean => {
   if (input) {
     if (_.toLower(input) === 'true') {
       return true;
@@ -47,6 +47,8 @@ export const stringToBoolean = (input: string): boolean => {
     if (isFinite(n) && !isNaN(n) && n > 0) {
       return true;
     }
+
+    return false;
   }
-  return false;
+  return defaultValue;
 };

--- a/test/aws/testHandler.ts
+++ b/test/aws/testHandler.ts
@@ -59,7 +59,7 @@ describe('AWS Handler', () => {
 
     bugsnagFactory.initialize.should.have.been.calledOnce();
     AWSConfigStub.should.be.calledOnce();
-    AWSConfigGetStub.should.be.calledThrice();
+    AWSConfigGetStub.getCalls().length.should.be.eql(3);
 
     AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
     AWSConfigGetStub.getCall(1).args.should.be.eql(['BUGSNAG_LAMBDAS_KEY']);
@@ -84,7 +84,7 @@ describe('AWS Handler', () => {
 
     bugsnagFactory.initialize.should.be.calledOnce();
     AWSConfigStub.should.be.calledOnce();
-    AWSConfigGetStub.should.be.calledThrice();
+    AWSConfigGetStub.getCalls().length.should.be.eql(3);
 
     AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
     AWSConfigGetStub.getCall(1).args.should.be.eql(['BUGSNAG_LAMBDAS_KEY']);
@@ -113,11 +113,12 @@ describe('AWS Handler', () => {
 
     bugsnagFactory.initialize.should.be.calledOnce();
     AWSConfigStub.should.be.calledOnce();
-    AWSConfigGetStub.should.be.calledThrice();
+    AWSConfigGetStub.getCalls().length.should.be.eql(4);
 
     AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
     AWSConfigGetStub.getCall(1).args.should.be.eql(['BUGSNAG_LAMBDAS_KEY']);
     AWSConfigGetStub.getCall(2).args.should.be.eql(['stage']);
+    AWSConfigGetStub.getCall(3).args.should.be.eql(['bugsnagEnabled']);
 
     bugsnag.notify.callCount.should.be.eql(1);
 
@@ -144,11 +145,12 @@ describe('AWS Handler', () => {
 
     bugsnagFactory.initialize.should.be.calledOnce();
     AWSConfigStub.should.be.calledOnce();
-    AWSConfigGetStub.should.be.calledThrice();
+    AWSConfigGetStub.getCalls().length.should.be.eql(4);
 
     AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
     AWSConfigGetStub.getCall(1).args.should.be.eql(['BUGSNAG_LAMBDAS_KEY']);
     AWSConfigGetStub.getCall(2).args.should.be.eql(['stage']);
+    AWSConfigGetStub.getCall(3).args.should.be.eql(['bugsnagEnabled']);
 
     bugsnag.notify.callCount.should.be.eql(1);
 

--- a/test/aws/testHandler.ts
+++ b/test/aws/testHandler.ts
@@ -27,6 +27,9 @@ describe('AWS Handler', () => {
     AWSConfigStub.prototype.get = () => {};
     AWSConfigGetStub = sinon.stub(AWSConfigStub.prototype, 'get');
 
+    AWSConfigGetStub.withArgs('bugsnagEnabled').resolves(true);
+    AWSConfigGetStub.resolves('');
+
     bugsnagFactory = { initialize: sinon.stub() };
     bugsnag = { notify: sinon.stub() };
     bugsnagFactory.initialize.resolves(bugsnag);
@@ -56,7 +59,11 @@ describe('AWS Handler', () => {
 
     bugsnagFactory.initialize.should.have.been.calledOnce();
     AWSConfigStub.should.be.calledOnce();
-    AWSConfigGetStub.should.be.calledTwice();
+    AWSConfigGetStub.should.be.calledThrice();
+
+    AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
+    AWSConfigGetStub.getCall(1).args.should.be.eql(['BUGSNAG_LAMBDAS_KEY']);
+    AWSConfigGetStub.getCall(2).args.should.be.eql(['stage']);
 
     bugsnag.notify.callCount.should.be.eql(0);
 
@@ -77,7 +84,11 @@ describe('AWS Handler', () => {
 
     bugsnagFactory.initialize.should.be.calledOnce();
     AWSConfigStub.should.be.calledOnce();
-    AWSConfigGetStub.should.be.calledTwice();
+    AWSConfigGetStub.should.be.calledThrice();
+
+    AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
+    AWSConfigGetStub.getCall(1).args.should.be.eql(['BUGSNAG_LAMBDAS_KEY']);
+    AWSConfigGetStub.getCall(2).args.should.be.eql(['stage']);
 
     bugsnag.notify.callCount.should.be.eql(0);
 
@@ -102,7 +113,11 @@ describe('AWS Handler', () => {
 
     bugsnagFactory.initialize.should.be.calledOnce();
     AWSConfigStub.should.be.calledOnce();
-    AWSConfigGetStub.should.be.calledTwice();
+    AWSConfigGetStub.should.be.calledThrice();
+
+    AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
+    AWSConfigGetStub.getCall(1).args.should.be.eql(['BUGSNAG_LAMBDAS_KEY']);
+    AWSConfigGetStub.getCall(2).args.should.be.eql(['stage']);
 
     bugsnag.notify.callCount.should.be.eql(1);
 
@@ -129,7 +144,11 @@ describe('AWS Handler', () => {
 
     bugsnagFactory.initialize.should.be.calledOnce();
     AWSConfigStub.should.be.calledOnce();
-    AWSConfigGetStub.should.be.calledTwice();
+    AWSConfigGetStub.should.be.calledThrice();
+
+    AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
+    AWSConfigGetStub.getCall(1).args.should.be.eql(['BUGSNAG_LAMBDAS_KEY']);
+    AWSConfigGetStub.getCall(2).args.should.be.eql(['stage']);
 
     bugsnag.notify.callCount.should.be.eql(1);
 

--- a/test/utils/testUtils.ts
+++ b/test/utils/testUtils.ts
@@ -2,7 +2,7 @@ import sinon = require('sinon');
 import should = require('should');
 require('should-sinon');
 
-import { normalizeUrl } from '../../src/utils/utils';
+import { normalizeUrl, stringToBoolean } from '../../src/utils/utils';
 
 describe('Normalizer', () => {
 
@@ -21,4 +21,25 @@ describe('Normalizer', () => {
   runTest('http://api.classy.org//a/', 'http://api.classy.org/a/');
   runTest('http://api.classy.org//a//', 'http://api.classy.org/a/');
   runTest('http://api.classy.org//a//b///////c///', 'http://api.classy.org/a/b/c/');
+});
+
+describe('stringToBoolean', () => {
+
+  const runTest = (input: string, expectedOutput: boolean) => {
+    it(`${input} should equate to boolean ${expectedOutput}`, async () => {
+      const output = stringToBoolean(input);
+      output.should.be.equal(expectedOutput);
+    });
+  };
+
+  runTest('true', true);
+  runTest('TRUE', true);
+  runTest('True', true);
+  runTest('false', false);
+  runTest('False', false);
+  runTest('FALSE', false);
+  runTest('SmiggenSmoggen', false);
+  runTest('0', false);
+  runTest('1', true);
+  runTest('10000', true);
 });


### PR DESCRIPTION
The "lambda" script ends up reporting errors to bugsnag when they fail while invoking lambdas locally.  We should disable this.