### PR TITLE
Log HTTP requests in lambdas

### DIFF
--- a/src/DataSources/Clients.ts
+++ b/src/DataSources/Clients.ts
@@ -18,6 +18,7 @@ export class ClientDataSource extends DataSource {
         await config.get('PAY_TOKEN'),
         await config.get('PAY_SECRET'), {
           timeout: await config.get('pay.timeout'),
+          log: await config.get('pay.log') ? await config.get('Logger') : undefined,
         });
     }
 
@@ -27,7 +28,10 @@ export class ClientDataSource extends DataSource {
         await config.get('APIV2_CLIENT_SECRET'),
         await config.get('api.oauthUrl'),
         await config.get('api.apiUrl'),
-        await config.get('api.timeout'),
+        {
+          timeout: await config.get('api.timeout'),
+          log: await config.get('api.log') ? await config.get('Logger') : undefined,
+        },
       );
     }
   }

--- a/src/aws/AWSConfig.ts
+++ b/src/aws/AWSConfig.ts
@@ -8,8 +8,8 @@ export class AWSConfig extends Config {
       require('../DataSources/Name')(appName),
       require('../DataSources/Environment'),
       require('../DataSources/Credstash'),
-      require('../DataSources/Clients'),
       require('../DataSources/Logging'),
+      require('../DataSources/Clients'),
       require('../DataSources/Replacer'),
     ]);
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,8 @@
+import * as Logger from 'bunyan';
+import request = require('request');
+import * as _ from 'lodash';
+import req = require('request-promise');
+
 export const safeStrConcat = (strings: Array<any>): string => {
   let output = '';
   for (const s of strings) {
@@ -35,3 +40,36 @@ export const normalizeUrl = (inputUrl: string): string => {
 const jsonParse = require('json-bigint')({ storeAsString: true }).parse;
 
 export const JSONParseBig = (json: string): any => require('json-bigint')({ storeAsString: true }).parse(json);
+
+type RequestOptionsWithUri = request.UriOptions & req.RequestPromiseOptions;
+type RequestOptionsWithUrl = request.UrlOptions & req.RequestPromiseOptions;
+export type RequestOptions = RequestOptionsWithUri | RequestOptionsWithUrl;
+
+const redactRequest = (obj: RequestOptions) => {
+  const retObj = _.cloneDeep<RequestOptions>(obj);
+
+  if (retObj.headers && retObj.headers.Authorization) {
+    retObj.headers.Authorization = '*** REDACTED ***';
+  }
+
+  return retObj;
+};
+
+export const requestWithLogs = async (options: RequestOptions, log?: Logger): Promise<request.Response> => {
+  const redactedOptions = redactRequest(options);
+  if (log) {
+    log.info(redactedOptions, 'Issued HTTP request');
+  }
+  let response: undefined|request.Response;
+  try {
+    return response = await req(options);
+  } finally {
+    if (log) {
+      if (_.get(response, 'statusCode') === 200) {
+        log.info({request: redactedOptions, response}, 'Received good response from request');
+      } else {
+        log.error({request: redactedOptions, response}, 'Received bad response from request');
+      }
+    }
+  }
+};

--- a/test/testAPIClient.ts
+++ b/test/testAPIClient.ts
@@ -5,6 +5,7 @@ import mock = require('mock-require');
 
 import { APIClient } from '../src/APIClient';
 import { oauth2tokenCallback } from 'oauth';
+import { normalizeUrl, JSONParseBig } from '../src/utils/utils';
 
 const SUCCESSFUL_EMPTY_JSON_RESPONSE = {
   statusCode: 200,
@@ -71,7 +72,7 @@ describe('API Client', () => {
   let apiClient: APIClient;
 
   beforeEach(() => {
-    mock('request-promise', requestStub);
+    mock('../src/utils/utils', {requestWithLogs: requestStub, normalizeUrl, JSONParseBig});
     mock('oauth', oauth);
     const mockAPIClient = mock.reRequire('../src/APIClient');
     apiClient = <APIClient> new mockAPIClient.APIClient(
@@ -113,7 +114,7 @@ describe('API Client', () => {
         'Authorization': 'Bearer ##BEARER_TOKEN##',
         'User-Agent': 'ClassyPay Node.JS',
       },
-    }]);
+    }, undefined]);
   });
 
   it('POST request', async () => {
@@ -143,7 +144,7 @@ describe('API Client', () => {
         'Content-Type': 'application/json',
       },
       body: '{"fake":"body"}',
-    }]);
+    }, undefined]);
   });
 
   it('PUT request', async () => {
@@ -173,7 +174,7 @@ describe('API Client', () => {
         'Content-Type': 'application/json',
       },
       body: '{"fake":"body"}',
-    }]);
+    }, undefined]);
   });
 
   it('DELETE request', async () => {
@@ -201,7 +202,7 @@ describe('API Client', () => {
         'Authorization': 'Bearer ##BEARER_TOKEN##',
         'User-Agent': 'ClassyPay Node.JS',
       },
-    }]);
+    }, undefined]);
   });
 
   it('Invalid GET request', async () => {
@@ -234,7 +235,7 @@ describe('API Client', () => {
         'Authorization': 'Bearer ##BEARER_TOKEN##',
         'User-Agent': 'ClassyPay Node.JS',
       },
-    }]);
+    }, undefined]);
 
     should.not.exist(result);
     should.exist(error);

--- a/test/testPayClient.ts
+++ b/test/testPayClient.ts
@@ -56,7 +56,7 @@ describe('PayClient', () => {
     mock('../src/utils/hmac256AuthSigner', {
       CreateHMACSigner: () => signStub,
     });
-    mock('request-promise', <StubFunction> requestStub);
+    mock('../src/utils/utils', {requestWithLogs: <StubFunction> requestStub});
 
     const mockPayClient = mock.reRequire('../src/PayClient');
     payClient = (<PayClient> new mockPayClient.default('##URL##', '##TOKEN##', '##SECRET##'));


### PR DESCRIPTION
Set a flag in env.yml under your Pay or API client configuration to enable all logging of requests and responses.