### PR TITLE
Fix behavior where end of readable stream reached

### DIFF
--- a/src/utils/PipeHelpers.ts
+++ b/src/utils/PipeHelpers.ts
@@ -23,6 +23,8 @@ export const readableStream = (handler: () => Promise<any>): stream.Readable =>
       }
       if (value) {
         this.push(value);
+      } else {
+        this.destroy();
       }
     },
   });


### PR DESCRIPTION
Needed a way to have a readable stream return when it's ended, and close the stream.