### PR TITLE
[CL-8720] don't throw err for success status range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-pay-core",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Shared tools used in ClassyPay-related projects",
   "main": "lib/index.js",
   "scripts": {

--- a/src/APIClient.ts
+++ b/src/APIClient.ts
@@ -92,7 +92,7 @@ export class APIClient {
     }
 
     const response = await requestWithLogs(options, this.log);
-    if (response.statusCode !== 200) {
+    if (response.statusCode < 200 || response.statusCode > 299) {
       throw new RequestResponseError(
         response,
         `API client received status code ${response.statusCode}: ${response.body}`,

--- a/src/PayClient.ts
+++ b/src/PayClient.ts
@@ -103,7 +103,7 @@ export class PayClient {
 
     const response = await requestWithLogs(options, this.log);
     const status = response.statusCode;
-    if (status !== 200) {
+    if (status < 200 || status > 299) {
       throw new Error(`Server returned error code ${status} from ${method} ${resource}: ${response && response.body}`);
     }
 
@@ -135,7 +135,7 @@ export class PayClient {
             undefined,
             {limit: PAGE_LIMIT, offset: page},
           );
-          if (innerResponse.status !== 200 || typeof innerResponse.object === 'string') {
+          if (innerResponse.status < 200 || innerResponse.status > 299 || typeof innerResponse.object === 'string') {
             throw new Error(`Expected server response with object, instead got: ${innerResponse}`);
           } else {
             return innerResponse.object;


### PR DESCRIPTION
We're throwing errors when response from Classypay is not 200 but is 2xx. Changing this to not throw errors when response is in the success range of [200, 299].