### PR TITLE
[CL-8270] fix unit tests

### DIFF
--- a/test/aws/testHandler.ts
+++ b/test/aws/testHandler.ts
@@ -58,8 +58,8 @@ describe('AWS Handler', () => {
     const result = await (<any> promisify(awsHandler(handlerStub, 'APP')))({}, {});
     result.should.be.eql('HELLO');
 
-    bugsnagFactory.initialize.should.have.been.calledOnce();
-    AWSConfigStub.should.be.calledOnce();
+    bugsnagFactory.initialize.calledOnce.should.be.True();
+    AWSConfigStub.calledOnce.should.be.True();
     AWSConfigGetStub.getCalls().length.should.be.eql(3);
 
     AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
@@ -68,7 +68,7 @@ describe('AWS Handler', () => {
 
     bugsnag.notify.callCount.should.be.eql(0);
 
-    handlerStub.should.be.calledOnce();
+    handlerStub.calledOnce.should.be.True();
   });
 
   it('Multiple handler calls should invoke initialization only once', async () => {
@@ -83,8 +83,8 @@ describe('AWS Handler', () => {
     await handler({}, {});
     await handler({}, {});
 
-    bugsnagFactory.initialize.should.be.calledOnce();
-    AWSConfigStub.should.be.calledOnce();
+    bugsnagFactory.initialize.calledOnce.should.be.True();
+    AWSConfigStub.calledOnce.should.be.True();
     AWSConfigGetStub.getCalls().length.should.be.eql(3);
 
     AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
@@ -93,7 +93,7 @@ describe('AWS Handler', () => {
 
     bugsnag.notify.callCount.should.be.eql(0);
 
-    handlerStub.should.be.calledThrice();
+    handlerStub.calledThrice.should.be.True();
   });
 
   it('Error should propagate correctly', async () => {
@@ -112,8 +112,8 @@ describe('AWS Handler', () => {
 
     should.exist(error);
 
-    bugsnagFactory.initialize.should.be.calledOnce();
-    AWSConfigStub.should.be.calledOnce();
+    bugsnagFactory.initialize.calledOnce.should.be.True();
+    AWSConfigStub.calledOnce.should.be.True();
     AWSConfigGetStub.getCalls().length.should.be.eql(4);
 
     AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
@@ -123,7 +123,7 @@ describe('AWS Handler', () => {
 
     bugsnag.notify.callCount.should.be.eql(1);
 
-    handlerStub.should.be.calledOnce();
+    handlerStub.calledOnce.should.be.True();
   });
 
   it('Wraps non-error object throwables in an Error object', async () => {
@@ -144,8 +144,8 @@ describe('AWS Handler', () => {
     (error instanceof Error).should.be.true();
     error.message.should.be.eql('{}');
 
-    bugsnagFactory.initialize.should.be.calledOnce();
-    AWSConfigStub.should.be.calledOnce();
+    bugsnagFactory.initialize.calledOnce.should.be.True();
+    AWSConfigStub.calledOnce.should.be.True();
     AWSConfigGetStub.getCalls().length.should.be.eql(4);
 
     AWSConfigGetStub.getCall(0).args.should.be.eql(['bugsnagEnabled']);
@@ -155,6 +155,6 @@ describe('AWS Handler', () => {
 
     bugsnag.notify.callCount.should.be.eql(1);
 
-    handlerStub.should.be.calledOnce();
+    handlerStub.calledOnce.should.be.True();
   });
 });

--- a/test/testPayClient.ts
+++ b/test/testPayClient.ts
@@ -76,9 +76,9 @@ describe('PayClient', () => {
       requestStub.resolves(SUCCESSFUL_EMPTY_JSON_RESPONSE);
       const obj = await payClient.get('appId', '/some/path');
       obj.should.be.eql({});
-      signStub.should.have.been.calledOnce();
+      signStub.calledOnce.should.be.True();
       signStub.getCall(0).args.should.be.eql(['GET', '/some/path', 'application/json', undefined]);
-      requestStub.should.have.been.calledOnce();
+      requestStub.calledOnce.should.be.True();
       requestStub.getCall(0).args[0].should.be.eql(buildExpectedRequest('GET', 'appId', '/some/path'));
     });
 
@@ -87,9 +87,9 @@ describe('PayClient', () => {
       requestStub.resolves(SUCCESSFUL_EMPTY_JSON_RESPONSE);
       const obj = await payClient.get('appId', '/some/path/2020-03-14');
       obj.should.be.eql({});
-      signStub.should.have.been.calledOnce();
+      signStub.calledOnce.should.be.True();
       signStub.getCall(0).args.should.be.eql(['GET', '/some/path/2020-03-14', 'application/json', undefined]);
-      requestStub.should.have.been.calledOnce();
+      requestStub.calledOnce.should.be.True();
       requestStub.getCall(0).args[0].should.be.eql(buildExpectedRequest('GET', 'appId', '/some/path/2020-03-14'));
     });
 
@@ -98,9 +98,9 @@ describe('PayClient', () => {
       requestStub.resolves(SUCCESSFUL_EMPTY_JSON_RESPONSE);
       const obj = await payClient.get('appId', '/some/path/ch_123');
       obj.should.be.eql({});
-      signStub.should.have.been.calledOnce();
+      signStub.calledOnce.should.be.True();
       signStub.getCall(0).args.should.be.eql(['GET', '/some/path/ch_123', 'application/json', undefined]);
-      requestStub.should.have.been.calledOnce();
+      requestStub.calledOnce.should.be.True();
       requestStub.getCall(0).args[0].should.be.eql(buildExpectedRequest('GET', 'appId', '/some/path/ch_123'));
     });
   });
@@ -110,9 +110,9 @@ describe('PayClient', () => {
     requestStub.resolves(SUCCESSFUL_EMPTY_JSON_RESPONSE);
     const obj = await payClient.post('appId', '/some/path', {});
     obj.should.be.eql({});
-    signStub.should.have.been.calledOnce();
+    signStub.calledOnce.should.be.True();
     signStub.getCall(0).args.should.be.eql(['POST', '/some/path', 'application/json', '{}']);
-    requestStub.should.have.been.calledOnce();
+    requestStub.calledOnce.should.be.True();
     requestStub.getCall(0).args[0].should.be.eql(buildExpectedRequest('POST', 'appId', '/some/path', '{}'));
   });
 
@@ -121,9 +121,9 @@ describe('PayClient', () => {
     requestStub.resolves(SUCCESSFUL_EMPTY_JSON_RESPONSE);
     const obj = await payClient.put('appId', '/some/path', {});
     obj.should.be.eql({});
-    signStub.should.have.been.calledOnce();
+    signStub.calledOnce.should.be.True();
     signStub.getCall(0).args.should.be.eql(['PUT', '/some/path', 'application/json', '{}']);
-    requestStub.should.have.been.calledOnce();
+    requestStub.calledOnce.should.be.True();
     requestStub.getCall(0).args[0].should.be.eql(buildExpectedRequest('PUT', 'appId', '/some/path', '{}'));
   });
 
@@ -132,9 +132,9 @@ describe('PayClient', () => {
     requestStub.resolves(SUCCESSFUL_EMPTY_JSON_RESPONSE);
     const obj = await payClient.del('appId', '/some/path');
     obj.should.be.eql({});
-    signStub.should.have.been.calledOnce();
+    signStub.calledOnce.should.be.True();
     signStub.getCall(0).args.should.be.eql(['DELETE', '/some/path', 'application/json', undefined]);
-    requestStub.should.have.been.calledOnce();
+    requestStub.calledOnce.should.be.True();
     requestStub.getCall(0).args[0].should.be.eql(buildExpectedRequest('DELETE', 'appId', '/some/path'));
   });
 
@@ -162,11 +162,11 @@ describe('PayClient', () => {
     ));
     const obj = await payClient.list('appId', '/some/path');
     obj.should.be.eql(_.map(_.range(0, 50), () => ({})));
-    signStub.should.have.been.calledThrice();
+    signStub.calledThrice.should.be.True();
     signStub.getCall(0).args.should.be.eql(['GET', '/some/path/count', 'application/json', undefined]);
     signStub.getCall(1).args.should.be.eql(['GET', '/some/path', 'application/json', undefined]);
     signStub.getCall(2).args.should.be.eql(['GET', '/some/path', 'application/json', undefined]);
-    requestStub.should.have.been.calledThrice();
+    requestStub.calledThrice.should.be.True();
     requestStub.getCall(0).args[0].should.be.eql(buildExpectedRequest('GET', 'appId', '/some/path/count'));
     requestStub.getCall(1).args[0].should.be.eql(
       buildExpectedRequest('GET', 'appId', '/some/path', undefined, {limit: 25, offset: 0}),
@@ -243,7 +243,7 @@ describe('PayClient', () => {
       }
       const obj = await payClient.forAppId('appId').get('/some/path');
       obj.should.be.eql({});
-      stubs.get.should.have.been.calledOnce();
+      stubs.get.calledOnce.should.be.True();
     });
 
     it('Post', async () => {
@@ -252,7 +252,7 @@ describe('PayClient', () => {
       }
       const obj = await payClient.forAppId('appId').post('/some/path', {});
       obj.should.be.eql({});
-      stubs.post.should.have.been.calledOnce();
+      stubs.post.calledOnce.should.be.True();
     });
 
     it('Put', async () => {
@@ -261,7 +261,7 @@ describe('PayClient', () => {
       }
       const obj = await payClient.forAppId('appId').put('/some/path', {});
       obj.should.be.eql({});
-      stubs.put.should.have.been.calledOnce();
+      stubs.put.calledOnce.should.be.True();
     });
 
     it('Del(ete)', async () => {
@@ -270,7 +270,7 @@ describe('PayClient', () => {
       }
       const obj = await payClient.forAppId('appId').del('/some/path');
       obj.should.be.eql({});
-      stubs.del.should.have.been.calledOnce();
+      stubs.del.calledOnce.should.be.True();
     });
 
     it('List', async () => {
@@ -279,7 +279,7 @@ describe('PayClient', () => {
       }
       const obj = await payClient.forAppId('appId').list('/some/path');
       obj.should.be.eql({});
-      stubs.list.should.have.been.calledOnce();
+      stubs.list.calledOnce.should.be.True();
     });
 
     it('Rejects non-string appId', async () => {

--- a/test/utils/testBugsnagFactory.ts
+++ b/test/utils/testBugsnagFactory.ts
@@ -60,9 +60,9 @@ describe('Bugsnag Factory', () => {
     if (!initialize || !processStubs || !bugsnagStubs) throw new Error('Test wasn\'t correctly set up');
     await initialize('appName', 'key', 'releaseStage');
     await initialize('appName', 'key', 'releaseStage');
-    processStubs.listeners.should.have.been.calledOnce();
-    processStubs.removeListener.should.have.been.calledTwice();
-    processStubs.on.should.have.been.calledTwice();
+    processStubs.listeners.calledOnce.should.be.True();
+    processStubs.removeListener.calledTwice.should.be.True();
+    processStubs.on.calledTwice.should.be.True();
     processStubs.on.getCall(0).args[0].should.be.eql('uncaughtException');
     processStubs.on.getCall(1).args[0].should.be.eql('unhandledRejection');
   });
@@ -82,7 +82,7 @@ describe('Bugsnag Factory', () => {
     if (!initialize || !processStubs || !bugsnagStubs) throw new Error('Test wasn\'t correctly set up');
     bugsnagStubs.notify.resetHistory();
     processStubs.on.getCall(0).args[1]('error');
-    bugsnagStubs.notify.should.have.been.calledOnce();
+    bugsnagStubs.notify.calledOnce.should.be.True();
     bugsnagStubs.notify.getCall(0).args[0].should.eql('error');
   });
 
@@ -90,7 +90,7 @@ describe('Bugsnag Factory', () => {
     if (!initialize || !processStubs || !bugsnagStubs) throw new Error('Test wasn\'t correctly set up');
     bugsnagStubs.notify.resetHistory();
     processStubs.on.getCall(1).args[1]('error');
-    bugsnagStubs.notify.should.have.been.calledOnce();
+    bugsnagStubs.notify.calledOnce.should.be.True();
     bugsnagStubs.notify.getCall(0).args[0].should.eql('error');
   });
 });

--- a/test/utils/testOnce.ts
+++ b/test/utils/testOnce.ts
@@ -18,7 +18,7 @@ describe('Once', () => {
     complete = true;
     await once.do();
     await once.do();
-    stub.should.be.calledOnce();
+    stub.calledOnce.should.be.True();
     once.getDone().should.be.equal(true);
   });
 });

--- a/test/utils/testThrottledRetrier.ts
+++ b/test/utils/testThrottledRetrier.ts
@@ -9,7 +9,7 @@ describe('Throttled retrier', () => {
     const stub = sinon.stub().resolves('BLAH');
     const f = throttledRetrier(stub, { disableErrorLogging: true });
     const v = await f();
-    stub.should.be.calledOnce();
+    stub.calledOnce.should.be.True();
     v.should.be.eql('BLAH');
   });
 
@@ -77,7 +77,7 @@ describe('Throttled retrier', () => {
       sleepAmountFunction: attemptNumber => 10 * attemptNumber,
     });
     const v = await f();
-    stub.should.be.calledTwice();
+    stub.calledTwice.should.be.True();
     v.should.be.eql('BLAH2');
   });
 
@@ -97,7 +97,7 @@ describe('Throttled retrier', () => {
     } catch (e) {
       error = e;
     }
-    stub.should.be.calledOnce();
+    stub.calledOnce.should.be.True();
     should.exist(error);
     should.not.exist(v);
   });


### PR DESCRIPTION
Fixing unit tests. Seems like a version change in test libraries has made the following assertion pattern invalid:
`stub.should.have.been.calledOnce()` 

Changing them to `stub.calledOnce.should.be.True()`