### PR TITLE
feat: [CL-55365] - Change md5 to sha256 for hashing all ClassyPay request bodies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-pay-core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shared tools used in ClassyPay-related projects",
   "main": "lib/index.js",
   "scripts": {

--- a/src/utils/hmac256AuthSigner.ts
+++ b/src/utils/hmac256AuthSigner.ts
@@ -12,7 +12,7 @@ export const CreateHMACSigner: HMACSignerFactory = (service: string, token: stri
 
   return (method, path, contentType, body) => {
     const ts = Math.floor(new Date().getTime() / 1000);
-    const bodyPart = body ? crypto.createHash('md5').update(body).digest('hex') : '';
+    const bodyPart = body ? crypto.createHash('sha256').update(body).digest('hex') : '';
     const message = `${method}\n${path}\n${(body ? contentType : '')}\n${ts}\n${bodyPart}`;
     const signature = crypto.createHmac('sha256', secret).update(message).digest('hex');
     return `${service} ts=${ts} token=${token} signature=${signature}`;

--- a/test/utils/testHmac256AuthSigner.ts
+++ b/test/utils/testHmac256AuthSigner.ts
@@ -21,7 +21,7 @@ describe('HMAC256AuthSigner', () => {
       }),
     });
     cryptoStubs = {
-      createHash: sinon.stub(crypto, 'createHash').returns(cryptoFaker('##MD5HASH##')),
+      createHash: sinon.stub(crypto, 'createHash').returns(cryptoFaker('##SHA256HASH##')),
       createHmac: sinon.stub(crypto, 'createHmac').returns(cryptoFaker('##SHA256HMAC##')),
     };
 
@@ -42,6 +42,7 @@ describe('HMAC256AuthSigner', () => {
     const signed = sign('method', 'path', 'contentType', 'body');
     signed.should.match(/^service ts=[0-9]+ token=token signature=##SHA256HMAC##$/);
     cryptoStubs.createHash.should.have.been.calledOnce();
+    cryptoStubs.createHash.should.have.been.calledWith('sha256');
     cryptoStubs.createHmac.should.have.been.calledOnce();
   });
 


### PR DESCRIPTION
As part of a Security request to deprecate the use of MD5 for hashing request bodies in ClassyPay, Classy-Pay-Core needs to be updated since it is a shared library used by various GFM Pro applications that make requests to Classy Pay.

Update to use SHA256, update unit tests.