### PR TITLE
fix: [CL-55365] - Fix error with attempting set operation on attribute with only getter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-pay-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Shared tools used in ClassyPay-related projects",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-pay-core",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Shared tools used in ClassyPay-related projects",
   "main": "lib/index.js",
   "scripts": {
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/classy-org/classy-pay-core",
   "dependencies": {
-    "axios": "^1.7.9",
+    "axios": "1.16.0",
     "bluebird": "^3.5.1",
     "bugsnag": "^2.1.3",
     "bunyan": "^1.8.14",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/classy-org/classy-pay-core",
   "dependencies": {
-    "axios": "1.16.0",
+    "axios": "1.17.0",
     "bluebird": "^3.5.1",
     "bugsnag": "^2.1.3",
     "bunyan": "^1.8.14",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -71,6 +71,21 @@ type AxiosRequestOptions = AxiosRequestConfig;
 
 type AxiosResponseWithBody<T = any> = AxiosResponse<T> & { body?: T };
 
+// Walks the prototype chain to find a property's descriptor, since the
+// property may be an accessor (getter/setter) defined on a prototype rather
+// than an own property of the object.
+const findPropertyDescriptor = (obj: object, key: string): PropertyDescriptor | undefined => {
+  let current: any = obj;
+  while (current) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, key);
+    if (descriptor) {
+      return descriptor;
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return undefined;
+};
+
 export const omitDeepWithKeys = (obj: any, excludeKeys: Array<string>, replacementValue?: string) => {
   const stackSet = new Set();
   const newObj = _.cloneDeep<any>(obj);
@@ -84,9 +99,20 @@ export const omitDeepWithKeys = (obj: any, excludeKeys: Array<string>, replaceme
 
 
     excludeKeys.forEach(key => {
+      const descriptor = findPropertyDescriptor(valueAsRecord, key);
       if (replacementValue && valueAsRecord[key] !== undefined) {
+        // Skip properties that can't be reassigned (e.g. getter-only accessors,
+        // possibly inherited from a prototype, or otherwise non-writable).
+        if (descriptor && !descriptor.writable && !descriptor.set) {
+          return;
+        }
         valueAsRecord[key] = replacementValue;
       } else {
+        // Skip properties that can't be deleted (non-configurable). Inherited
+        // properties have no own descriptor here, so delete is a safe no-op.
+        if (descriptor && !descriptor.configurable && Object.prototype.hasOwnProperty.call(valueAsRecord, key)) {
+          return;
+        }
         delete valueAsRecord[key];
       }
     });

--- a/test/utils/testUtils.ts
+++ b/test/utils/testUtils.ts
@@ -3,7 +3,7 @@ import should = require('should');
 import * as _ from 'lodash';
 
 // tslint:disable-next-line:max-line-length
-import { normalizeUrl, stringToBoolean, redact, sequelizeCloneDeep, recurse, runFunctionAfterDelay } from '../../src/utils/utils';
+import { normalizeUrl, stringToBoolean, redact, omitDeepWithKeys, sequelizeCloneDeep, recurse, runFunctionAfterDelay } from '../../src/utils/utils';
 require('should-sinon');
 
 describe('Normalizer', () => {
@@ -158,6 +158,92 @@ describe('Redact', () => {
         'content-length': 5857,
       },
     },
+  });
+});
+
+describe('omitDeepWithKeys non-writable properties', () => {
+  // Builds an object whose `source` is an accessor on its prototype, rather
+  // than an own property. This reproduces the production failure: _.cloneDeep
+  // converts own getters into writable values but preserves the prototype, so
+  // an inherited getter-only accessor survives the clone. `hasSetter` controls
+  // whether a setter is also present.
+  const withPrototypeAccessor = (ownProps: object, hasSetter = false) => {
+    let backing = 'card';
+    const descriptor: PropertyDescriptor = {
+      enumerable: false,
+      configurable: true,
+      get: () => backing,
+    };
+    if (hasSetter) {
+      descriptor.set = (value: string) => { backing = value; };
+    }
+    const proto = {};
+    Object.defineProperty(proto, 'source', descriptor);
+    return Object.assign(Object.create(proto), ownProps);
+  };
+
+  it('does not throw and skips a getter-only property inherited from a prototype', () => {
+    let output: any;
+    (() => {
+      output = omitDeepWithKeys(
+        withPrototypeAccessor({ email: 'user@example.com' }),
+        ['email', 'source'],
+        '*** REDACTED ***',
+      );
+    }).should.not.throw();
+
+    // Writable property is redacted as normal.
+    output.email.should.be.equal('*** REDACTED ***');
+    // Getter-only property is left intact rather than crashing.
+    output.source.should.be.equal('card');
+  });
+
+  it('does not throw on the delete path (no replacement value) for a prototype getter-only property', () => {
+    let output: any;
+    (() => {
+      // No replacementValue => delete path. Deleting an inherited accessor is a
+      // no-op rather than a crash.
+      output = omitDeepWithKeys(
+        withPrototypeAccessor({ email: 'user@example.com' }),
+        ['email', 'source'],
+      );
+    }).should.not.throw();
+
+    // Writable own property is removed.
+    should.not.exist(output.email);
+    // Inherited getter is untouched and still readable.
+    output.source.should.be.equal('card');
+  });
+
+  it('redacts a getter property that also has a setter', () => {
+    let output: any;
+    (() => {
+      output = omitDeepWithKeys(
+        withPrototypeAccessor({}, true),
+        ['source'],
+        '*** REDACTED ***',
+      );
+    }).should.not.throw();
+
+    // A setter exists, so the value can be (and is) redacted.
+    output.source.should.be.equal('*** REDACTED ***');
+  });
+
+  it('redacts nested writable properties even when a sibling is getter-only', () => {
+    const input = {
+      outer: {
+        email: 'user@example.com',
+        nested: withPrototypeAccessor({}),
+      },
+    };
+
+    let output: any;
+    (() => {
+      output = omitDeepWithKeys(input, ['email', 'source'], '*** REDACTED ***');
+    }).should.not.throw();
+
+    output.outer.email.should.be.equal('*** REDACTED ***');
+    output.outer.nested.source.should.be.equal('card');
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,7 +393,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-axios@*, axios@^1.7.9:
+axios@*:
   version "1.7.9"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
   integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
@@ -401,6 +401,15 @@ axios@*, axios@^1.7.9:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
+
+axios@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
+  dependencies:
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    proxy-from-env "^2.1.0"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -1028,6 +1037,16 @@ es-set-tostringtag@^2.0.3:
     has-tostringtag "^1.0.2"
     hasown "^2.0.1"
 
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
 es-to-primitive@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.3.0.tgz#96c89c82cc49fd8794a24835ba3e1ff87f214e18"
@@ -1249,6 +1268,11 @@ follow-redirects@^1.15.6:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -1269,6 +1293,17 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+form-data@^4.0.5:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -1519,6 +1554,13 @@ hasown@^2.0.1, hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -2092,7 +2134,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@^2.1.35, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -2502,6 +2544,11 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 pseudomap@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,6 +193,13 @@ aes-js@^3.1.0:
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.1.2.tgz#db9aabde85d5caabbfc0d4f2a4446960f627146a"
   integrity sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -402,13 +409,14 @@ axios@*:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
-  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
+axios@1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.17.0.tgz#ae5a1164a4f719942cd73c67e6a3f62d3ccb8f2b"
+  integrity sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==
   dependencies:
     follow-redirects "^1.16.0"
     form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
     proxy-from-env "^2.1.0"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
@@ -844,6 +852,13 @@ debug@3.2.6:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
@@ -1578,6 +1593,14 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 iconv-lite@^0.4.17:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -2241,7 +2264,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.1.1:
+ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==


### PR DESCRIPTION
In Classypay to Classy (CP2CL), there was a persistent issue with transactions failing to sync due to an error within classy-pay-core. The issue was with the omitDeepWithKeys method trying to use a setter on a property from the request that only had a getter. This prevented any transaction from syncing in cp2cl when using v0.4.0 of classy-pay-core.

Fix: 
- bump classy-pay-core version to 0.5.0
- update axios to 1.17.0
- Skip setter on properties with only getter
- Skip deletion on non-configurable properties