### PR TITLE
fix: [CL-55365] - Rebuild fresh library to commit with package upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-pay-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Shared tools used in ClassyPay-related projects",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "yarn run lint && node_modules/typescript/bin/tsc -p ./",
     "tslint": "find src/ test/ -iname \"*.ts\" | xargs node_modules/tslint/bin/tslint -c ./tslint.json",
     "lint": "yarn run tslint",
-    "prepublish": "yarn run clean && yarn run test && yarn run build",
+    "prepublishOnly": "yarn run clean && yarn run test && yarn run build",
     "clean": "rm -rfv lib"
   },
   "repository": {


### PR DESCRIPTION
After publishing the latest version of the package, it was detected that a stale lib was shipped with the source code of the newly published package version. To fix this, package.json was upgraded to 0.5.1 and the npm script prepublish was updated since it has been deprecated.