### PR TITLE
fix: [noTix] - Add fix for improper log redaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-pay-core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Shared tools used in ClassyPay-related projects",
   "main": "lib/index.js",
   "scripts": {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -149,6 +149,47 @@ export const redact = (obj: any) =>
     '*** REDACTED ***'
   );
 
+// If `data` is a serialized JSON string (as axios stores request bodies on
+// `config.data`), parse it back into an object so the key-based `redact()` can
+// reach the PII inside it. Otherwise key-based redaction is blind to it.
+const parseIfJSONString = (data: any): any =>
+  typeof data === 'string' && isJSONString(data) ? JSON.parse(data) : data;
+
+// Projects an axios response down to only the fields that are safe and useful
+// to log. The raw response object carries the Node http.ClientRequest (open
+// sockets, TLS session keys, the raw `Authorization: Bearer ...` header string)
+// and `config.data` (the request body as an unredactable serialized string) —
+// none of which `redact()` can scrub. We drop `config` and `request` entirely.
+const toSafeLogResponse = (response?: AxiosResponseWithBody) => {
+  if (!response) {
+    return response;
+  }
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+    data: parseIfJSONString(response.data),
+  };
+};
+
+// Projects an error down to a safe shape. For an AxiosError this strips the
+// embedded `config`/`request` (which leak the same way as above) and keeps only
+// the message, code, stack, and a sanitized response.
+const toSafeLogError = (error?: Error) => {
+  if (!error) {
+    return error;
+  }
+  if (axios.isAxiosError(error)) {
+    return {
+      message: error.message,
+      code: error.code,
+      stack: error.stack,
+      response: toSafeLogResponse(error.response as AxiosResponseWithBody),
+    };
+  }
+  return { message: error.message, stack: error.stack };
+};
+
 export const requestWithLogs = async (
   options: AxiosRequestOptions,
   log?: Logger
@@ -181,17 +222,17 @@ export const requestWithLogs = async (
         statusCode = error.response.status;
       }
       if (statusCode === 200 && error === undefined) {
-        const toRedactResponse = _.cloneDeep(response);
-        if (toRedactResponse?.data && isJSONString(JSON.stringify(toRedactResponse.data))) {
-          toRedactResponse.data = JSON.parse(JSON.stringify(toRedactResponse.data));
-        }
         log.info(
-          redact({ request: options, response: toRedactResponse }),
+          redact({ request: options, response: toSafeLogResponse(response) }),
           `Response (Good) ${logString}`
         );
       } else {
         log.error(
-          redact({ request: options, response, error }),
+          redact({
+            request: options,
+            response: toSafeLogResponse(response),
+            error: toSafeLogError(error),
+          }),
           `Response (Bad${statusCode ? ' - ' + statusCode : ''}) ${logString}`
         );
       }

--- a/test/utils/testUtils.ts
+++ b/test/utils/testUtils.ts
@@ -1,5 +1,6 @@
 import sinon = require('sinon');
 import should = require('should');
+import mock = require('mock-require');
 import * as _ from 'lodash';
 
 // tslint:disable-next-line:max-line-length
@@ -244,6 +245,111 @@ describe('omitDeepWithKeys non-writable properties', () => {
 
     output.outer.email.should.be.equal('*** REDACTED ***');
     output.outer.nested.source.should.be.equal('card');
+  });
+});
+
+describe('requestWithLogs', () => {
+  // A response shaped like a real axios response: it carries the Node
+  // http.ClientRequest (sockets, raw `Authorization` header string) and a
+  // `config` whose `data` is the request body as a serialized JSON string.
+  // Neither is reachable by key-based redaction, so they must not be logged.
+  const SECRET_TOKEN = 'h72deiQjXxCZLlv1';
+  const buildAxiosResponse = () => {
+    const requestBody = {
+      first_name: 'Taz',
+      email: 'thammer@test.com',
+      address1: '580 Memorial Road',
+      metadata: { token: SECRET_TOKEN },
+    };
+    return {
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json' },
+      data: { ok: true, email: 'thammer@test.com' },
+      config: {
+        url: 'https://api.example.org/x',
+        method: 'put',
+        // Serialized request body — PII is inside a string here.
+        data: JSON.stringify(requestBody),
+        headers: { Authorization: 'Bearer ' + SECRET_TOKEN },
+      },
+      request: {
+        // Raw HTTP header string containing the bearer token in plaintext.
+        _header: 'PUT /x HTTP/1.1\nAuthorization: Bearer ' + SECRET_TOKEN + '\n\n',
+        socket: { _tlsOptions: { session: { type: 'Buffer', data: [1, 2, 3] } } },
+      },
+    };
+  };
+
+  let requestWithLogs: any;
+  let logInfoArg: any;
+
+  const setupWithAxios = (axiosImpl: any) => {
+    mock('axios', axiosImpl);
+    requestWithLogs = mock.reRequire('../../src/utils/utils').requestWithLogs;
+  };
+
+  afterEach(() => {
+    mock.stopAll();
+    logInfoArg = undefined;
+  });
+
+  it('does not log config, request, sockets, or the serialized request body on success', async () => {
+    const axiosImpl: any = async () => buildAxiosResponse();
+    axiosImpl.isAxiosError = () => false;
+    setupWithAxios(axiosImpl);
+
+    const log: any = {
+      info: (obj: any) => { logInfoArg = obj; },
+      error: () => { /* not expected */ },
+    };
+
+    await requestWithLogs({ url: 'https://api.example.org/x', method: 'PUT' }, log);
+
+    should.exist(logInfoArg);
+    // The whole axios object must not be dumped.
+    should.not.exist(logInfoArg.response.config);
+    should.not.exist(logInfoArg.response.request);
+    // Only the safe projection survives.
+    logInfoArg.response.status.should.equal(200);
+    logInfoArg.response.statusText.should.equal('OK');
+
+    // The bearer token must appear nowhere in the serialized log payload.
+    const serialized = JSON.stringify(logInfoArg);
+    serialized.should.not.containEql(SECRET_TOKEN);
+    // Response-body PII is still redacted by key.
+    logInfoArg.response.data.email.should.equal('*** REDACTED ***');
+  });
+
+  it('does not leak the raw request/config on error responses', async () => {
+    const axiosError: any = new Error('boom');
+    axiosError.config = { data: JSON.stringify({ token: SECRET_TOKEN }) };
+    axiosError.request = { _header: 'Authorization: Bearer ' + SECRET_TOKEN };
+    axiosError.response = { status: 500, statusText: 'ERR', headers: {}, data: 'nope' };
+
+    const axiosImpl: any = async () => { throw axiosError; };
+    axiosImpl.isAxiosError = (e: any) => e === axiosError;
+    setupWithAxios(axiosImpl);
+
+    let errorArg: any;
+    const log: any = {
+      info: () => { /* not expected */ },
+      error: (obj: any) => { errorArg = obj; },
+    };
+
+    let threw = false;
+    try {
+      await requestWithLogs({ url: 'https://api.example.org/x', method: 'PUT' }, log);
+    } catch (e) {
+      threw = true;
+    }
+    threw.should.equal(true);
+
+    should.exist(errorArg);
+    should.not.exist(errorArg.error.config);
+    should.not.exist(errorArg.error.request);
+    errorArg.error.message.should.equal('boom');
+    JSON.stringify(errorArg).should.not.containEql(SECRET_TOKEN);
   });
 });
 


### PR DESCRIPTION
1. Root cause — the request → axios migration (commit 9ffad4a, "fix critical cves", Jan 27 2026).
  Before that, the HTTP client was the request/request-promise library. Its response was lean: { statusCode, body, headers }, where body was a string the code parsed and redacted. There was no config.data, no request._header, no socket dump.

  The CVE refactor swapped in axios but left the redaction logic untouched. An axios response is a fundamentally fatter object:
  - config.data — request body as a serialized JSON string (unredactable by key)
  - request._header — raw header string with the bearer token
  - request — the whole Node socket/TLS state

  So the leak was latent from the migration — redact({request, response, error}) was written for the old lean shape.

  2. What made it actually appear in logs — the getter fix (commit f24b8ba, June 23 2026).
  Here's why it stayed hidden for ~5 months. The pre-fix omitDeepWithKeys did a blind assignment:

  valueAsRecord[key] = replacementValue;   // no descriptor check

  Axios 1.x objects (AxiosHeaders, the TLS socket, etc.) expose getter-only properties. When redact walked the cloned response and hit one whose name matched the blocklist (e.g. source, state), that assignment threw Cannot set property … which has only a getter. Because the redact(...) call sits inside log.info(...) in the finally block, the throw aborted the log line — the bad payload was never emitted. The leak was masked by a crash.

  Commit # f24b8ba fixed that crash by skipping non-writable/getter-only properties instead of throwing. Correct fix for the crash — but it let redact run to completion on the axios object for the first time, and the full dump (with config.data and request._header) finally made it into the logs.

  So, the migration from request to axios planted the leak; the recent getter-only fix unmasked it by letting the redactor finish instead of crashing.