### PR TITLE
fix: [CL-55365] - send no Content-Type on bodyless requests to prevent HMAC signature rejection

### DIFF
--- a/src/PayClient.ts
+++ b/src/PayClient.ts
@@ -61,7 +61,7 @@ export class PayClient {
         payload ? JSON.stringify(payload) : undefined
       ),
       'User-Agent': 'ClassyPay Node.JS',
-      'Content-Type': payload ? 'application/json' : undefined,
+      'Content-Type': payload ? 'application/json' : null,
     };
     if (this.version) {
       headers['x-classypay-version'] = this.version;

--- a/test/testPayClient.ts
+++ b/test/testPayClient.ts
@@ -40,7 +40,7 @@ const buildExpectedRequest = (method: string, appId: string, path: string, data?
     headers: {
       'Authorization': '##SIGNATURE##',
       'User-Agent': 'ClassyPay Node.JS',
-      'Content-Type': data ? 'application/json' : undefined,
+      'Content-Type': data ? 'application/json' : null,
     },
   }
 
@@ -148,6 +148,27 @@ describe('PayClient', () => {
     requestStub.getCall(0).args[0].should.be.eql(buildExpectedRequest('DELETE', 'appId', '/some/path'));
   });
 
+  it('sends no Content-Type header when there is no payload', async () => {
+    if (!requestStub || !signStub || !payClient) throw new Error('Cannot start test, beforeEach() wasn\'t run');
+    requestStub.resolves(SUCCESSFUL_EMPTY_JSON_RESPONSE);
+    // A bodyless PUT (e.g. a refund) must not carry a Content-Type. The signer omits it from the
+    // signed message when there is no body, so axios must not inject its `application/x-www-form-urlencoded`
+    // default (which it does when the header is `undefined`) or the server rejects the HMAC signature.
+    await payClient.put('appId', '/some/path', undefined as any);
+    requestStub.calledOnce.should.be.True();
+    const sentHeaders = requestStub.getCall(0).args[0].headers;
+    should(sentHeaders['Content-Type']).be.null();
+    sentHeaders.should.not.have.property('Content-Type', undefined);
+  });
+
+  it('sends application/json Content-Type when there is a payload', async () => {
+    if (!requestStub || !signStub || !payClient) throw new Error('Cannot start test, beforeEach() wasn\'t run');
+    requestStub.resolves(SUCCESSFUL_EMPTY_JSON_RESPONSE);
+    await payClient.put('appId', '/some/path', {a: 1});
+    requestStub.calledOnce.should.be.True();
+    requestStub.getCall(0).args[0].headers['Content-Type'].should.be.eql('application/json');
+  });
+
   it('List', async () => {
     if (!requestStub || !signStub || !payClient) throw new Error('Cannot start test, beforeEach() wasn\'t run');
     // @ts-ignore
@@ -163,7 +184,7 @@ describe('PayClient', () => {
       headers: {
         'Authorization': '##SIGNATURE##',
         'User-Agent': 'ClassyPay Node.JS',
-        'Content-Type': undefined,
+        'Content-Type': null,
       },
     }).resolves(_.extend(_.clone(SUCCESSFUL_EMPTY_JSON_RESPONSE), {data: {'count':40}}));
     requestStub.resolves(_.extend(


### PR DESCRIPTION
## Summary
  Bodyless requests (refunds, GETs, DELETEs, empty-body PUT/POST) were being rejected
  by ClassyPay with `401 Authentication failed: hmac invalid signature`. This fixes the
  root cause by ensuring no `Content-Type` header is sent when there is no payload.

  ## Root cause
  The HMAC signer (`hmac256AuthSigner.ts`) only includes the content-type in the signed
  message when a body is present:

  message = ${method}\n${path}\n${(body ? contentType : '')}\n${ts}\n${bodyPart};

  So for a bodyless request the signed content-type is an empty string. The server rebuilds
  this same canonical string from the request it receives — including the `Content-Type`
  header — so any content-type on a bodyless request makes the server's hash diverge from
  what we signed.

  `PayClient.getHeaders` sets `'Content-Type': payload ? 'application/json' : undefined`.
  That code never changed — but the HTTP client under it did. Commit 9ffad4a migrated from
  `request`/`request-promise` to `axios`, and the two libraries treat an `undefined` header
  value differently:

  | HTTP client | bodyless request, `Content-Type: undefined` | Content-Type on the wire |
  |-------------|---------------------------------------------|--------------------------|
  | `request` 2.88.2 (old) | honored as "no header" | *(none)* |
  | `axios` 1.17.0 (new)   | treated as "use method default" | `application/x-www-form-urlencoded` |

  With `request`, bodyless calls went out with no Content-Type, matching the empty
  content-type we signed. axios injects `application/x-www-form-urlencoded` instead, so the
  server folds a content-type into its canonical string that we never signed → HMAC mismatch.

  Note: this is **not** caused by the `axios ^1.7.9 → 1.17.0` bump — both axios versions
  inject the header identically (verified). The regression was the request→axios migration.

  ## Fix
  Set the header to `null` instead of `undefined` when there is no payload. Unlike
  `undefined`, `null` makes axios omit the header entirely, restoring the pre-migration
  wire behavior:

  ```diff
  - 'Content-Type': payload ? 'application/json' : undefined,
  + 'Content-Type': payload ? 'application/json' : null,

  Tests

  - Added sends no Content-Type header when there is no payload — asserts the outgoing
  header is null for a bodyless request.
  - Added sends application/json Content-Type when there is a payload — pins the other branch.
  - Updated existing expectations (buildExpectedRequest helper + inline List case) from
  undefined to null to match the fix.
  - Full suite: 89 passing, lint clean.

  Impact

  Affects all bodyless verbs (GET, DELETE, bodyless PUT/POST), not just refunds — the
  migration merely exposed a latent client/server content-type asymmetry.